### PR TITLE
Use regexp.QuoteMeta instead of \Q and \E

### DIFF
--- a/server.go
+++ b/server.go
@@ -58,7 +58,7 @@ func (c *Config) CreateProxy() (Proxy, error) {
 			if server.Regexp {
 				host_regexp, err = regexp.Compile(hostname)
 			} else {
-				host_regexp, err = regexp.Compile("^\\Q" + hostname + "\\E$")
+				host_regexp, err = regexp.Compile("^" + regexp.QuoteMeta(hostname) + "$")
 			}
 			if err != nil {
 				return Proxy{}, err


### PR DESCRIPTION
Thanks to @dnesting for the suggestion!
