### PR TITLE
Fix range check to avoid index out of range panic

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -85,7 +85,7 @@ func GetSNBlock(data []byte) ([]byte, error) {
 	data = data[2 : extensionLength+2]
 
 	for {
-		if index >= len(data) {
+		if index+4 >= len(data) {
 			break
 		}
 		length := int((data[index+2] << 8) + data[index+3])


### PR DESCRIPTION
My server crashed with `panic: runtime error: index out of range` due to an incorrect range check. This PR should fix it by making sure there's enough buffer before reading a length value out of the SNI extension.

Error message and stack trace:

```
Mar 12 21:12:57 raspberrypi sniff[454]: 2017/03/12 21:12:57 Error: EOF
Mar 12 21:12:58 raspberrypi sniff[454]: 2017/03/12 21:12:58 Error: read tcp 192.175.111.254:5831: connection reset by peer
Mar 12 21:13:00 raspberrypi sniff[454]: 2017/03/12 21:13:00 Error: EOF
Mar 12 21:13:01 raspberrypi sniff[454]: 2017/03/12 21:13:01 Error: read tcp 192.175.111.254:26998: connection reset by peer
Mar 12 21:13:06 raspberrypi sniff[454]: panic: runtime error: index out of range
Mar 12 21:13:06 raspberrypi sniff[454]: goroutine 25485 [running]:
Mar 12 21:13:06 raspberrypi sniff[454]: pault.ag/go/sniff/parser.GetSNBlock(0x1046d0dc, 0x29, 0xf24, 0x0, 0x0, 0x0, 0x0, 0x0)
Mar 12 21:13:06 raspberrypi sniff[454]: /home/pi/go/src/pault.ag/go/sniff/parser/parser.go:91 +0x224
Mar 12 21:13:06 raspberrypi sniff[454]: pault.ag/go/sniff/parser.GetHostname(0x1046d000, 0x1000, 0x1000, 0x0, 0x0, 0x0, 0x0)
Mar 12 21:13:06 raspberrypi sniff[454]: /home/pi/go/src/pault.ag/go/sniff/parser/parser.go:42 +0xe0
Mar 12 21:13:06 raspberrypi sniff[454]: main.(*Proxy).Handle(0x104362a0, 0xb6d39a10, 0x1040a330)
Mar 12 21:13:06 raspberrypi sniff[454]: /home/pi/go/src/github.com/divergentdave/sniff/server.go:110 +0x174
Mar 12 21:13:06 raspberrypi sniff[454]: created by main.(*Config).Serve
Mar 12 21:13:06 raspberrypi sniff[454]: /home/pi/go/src/github.com/divergentdave/sniff/server.go:97 +0x2a0
...
```