### PR TITLE
Remove some logging, make some configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -28,6 +28,7 @@ import (
 type Config struct {
 	Bind    Bind
 	Servers []Server
+	Verbose bool
 }
 
 type Bind struct {

--- a/server.go
+++ b/server.go
@@ -141,7 +141,7 @@ func (s *Proxy) Handle(conn net.Conn) {
 		conn.Close()
 		return
 	}
-	n, err := clientConn.Write(data[:length])
+	_, err = clientConn.Write(data[:length])
 	if err != nil {
 		log.Printf("Error: %s", err)
 		conn.Close()

--- a/sniff.json
+++ b/sniff.json
@@ -14,5 +14,6 @@
             ],
             "port": 443
         }
-    ]
+    ],
+    "verbose": false
 }


### PR DESCRIPTION
This gets rid of some of some logging statements, and places others behind a "verbose" flag in the sniff.json config file.