### PR TITLE
Fix a small error in various length computations

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -44,6 +44,14 @@ func GetHostname(data []byte) (string, error) {
 	return string(sni), nil
 }
 
+/* Return the length computed from the two octets starting at index */
+func lengthFromData(data []byte, index int) int {
+	b1 := int(data[index])
+	b2 := int(data[index+1])
+
+	return (b1 << 8) + b2
+}
+
 /* Given a Server Name TLS Extension block, parse out and return the SNI
  * (Server Name Indication) payload */
 func GetSNIBlock(data []byte) ([]byte, error) {
@@ -53,11 +61,11 @@ func GetSNIBlock(data []byte) ([]byte, error) {
 		if index >= len(data) {
 			break
 		}
-		length := int((data[index] << 8) + data[index+1])
+		length := lengthFromData(data, index)
 		endIndex := index + 2 + length
 		if data[index+2] == 0x00 { /* SNI */
 			sni := data[index+3:]
-			sniLength := int((sni[0] << 8) + sni[1])
+			sniLength := lengthFromData(sni, 0)
 			return sni[2 : sniLength+2], nil
 		}
 		index = endIndex
@@ -75,7 +83,7 @@ func GetSNBlock(data []byte) ([]byte, error) {
 		return []byte{}, fmt.Errorf("Not enough bytes to be an SN block")
 	}
 
-	extensionLength := int((data[index] << 8) + data[index+1])
+	extensionLength := lengthFromData(data, index)
 	if extensionLength+2 > len(data) {
 		return []byte{}, fmt.Errorf("Extension looks bonkers")
 	}
@@ -85,7 +93,7 @@ func GetSNBlock(data []byte) ([]byte, error) {
 		if index+3 >= len(data) {
 			break
 		}
-		length := int((data[index+2] << 8) + data[index+3])
+		length := lengthFromData(data, index+2)
 		endIndex := index + 4 + length
 		if data[index] == 0x00 && data[index+1] == 0x00 {
 			return data[index+4 : endIndex], nil
@@ -121,7 +129,7 @@ func GetExtensionBlock(data []byte) ([]byte, error) {
 	}
 
 	/* Index is at Cipher List Length bits */
-	if newIndex := (index + 2 + int((data[index]<<8)+data[index+1])); (newIndex + 1) < len(data) {
+	if newIndex := (index + 2 + lengthFromData(data, index)); (newIndex + 1) < len(data) {
 		index = newIndex
 	} else {
 		return []byte{}, fmt.Errorf("Not enough bytes for the Cipher List")

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,0 +1,125 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestLengthFromData(t *testing.T) {
+	cases := []struct{
+		data     []byte
+		index    int
+		expected int
+	}{
+		{[]byte{0x00, 0x00}, 0, 0},
+		{[]byte{0x00, 0xf0}, 0, 240},
+		{[]byte{0x01, 0x01}, 0, 257},
+		{[]byte{0x01, 0x00}, 0, 256},
+		{[]byte{0x01, 0x00, 0x00}, 1, 0},
+		{[]byte{0x01, 0x00, 0xff}, 0, 256},
+	}
+
+	for ix, data := range cases {
+		seen := lengthFromData(data.data, data.index)
+		if seen != data.expected {
+			t.Errorf("Test case #%d, saw %d, expected %d", ix, seen, data.expected)
+		}
+	}
+}
+
+func TestGetSNIBlock(t *testing.T) {
+	cases := []struct{
+		data     []byte
+		hostname string
+		err      bool
+	}{
+		{
+			[]byte{0x00, 0x06, 0x00, 0x00, 0x03, 0x66, 0x6f, 0x6f},
+			"foo",
+			false,
+		},
+		{
+			[]byte{0x00, 0x06, 0x01, 0x00, 0x03, 0x66, 0x6f, 0x6f},
+			"",
+			true,
+		},
+		{
+			[]byte{
+				0x01, 0x06, 0x01, 0x00, 0x03, 0x66, 0x6f, 0x6f,
+				0x00, 0x06, 0x00, 0x00, 0x03, 0x66, 0x6f, 0x6f,
+			},
+			"",
+			true,
+		},
+		{
+			[]byte{
+				0x00, 0x06, 0x01, 0x00, 0x03, 0x66, 0x6f, 0x6f,
+				0x00, 0x06, 0x00, 0x00, 0x03, 0x66, 0x6f, 0x6f,
+			},
+			"foo",
+			false,
+		},
+	}
+
+	for ix, data := range cases {
+		sni, err := GetSNIBlock(data.data)
+
+		sawErr := (err != nil)
+		if sawErr != data.err {
+			t.Errorf("Unexpected error status in test case #%d, error present %v, expected %v", ix, sawErr, data.err)
+		} else {
+			seen := string(sni)
+			expected := data.hostname
+
+			if seen != expected {
+				t.Errorf("IN test case #%d, saw hostname %s, expected %s", ix, seen, expected)
+			}
+		}
+	}
+}
+
+func cmpByteSlice(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for ix, val := range a {
+		if val != b[ix] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestGetSNBlock(t *testing.T) {
+	cases := []struct{
+		data     []byte
+		err      bool
+		expected []byte
+	}{
+		{
+			[]byte{0x00, 0x07, 0x00, 0x00, 0x00, 0x03, 0x01, 0x02, 0x03},
+			false,
+			[]byte{0x01, 0x02, 0x03},
+		},
+		{
+			[]byte{0x01, 0x07, 0x00, 0x00, 0x00, 0x03, 0x01, 0x02, 0x03},
+			true,
+			[]byte{},
+		},
+	}
+
+	for ix, data := range cases {
+		sn, err := GetSNBlock(data.data)
+
+		sawErr := (err != nil)
+		if sawErr != data.err {
+			t.Errorf("Unexpected error status in test case #%d, error present %v, expected %v", ix, sawErr, data.err)
+		} else {
+			if !cmpByteSlice(sn, data.expected) {
+				t.Errorf("IN test case #%d, saw SN %#v, expected %#v", ix, sn, data.expected)
+			}
+		}
+	}
+	
+}


### PR DESCRIPTION
This adds a few (not enough, but enough to cover the bulk of the changes) unit tests and fixes a few parsing bugs that stem from `(byte(n) << 8) == 0`.